### PR TITLE
Unify Identity Management

### DIFF
--- a/app/client/templates/components/itemSelectedAccount.html
+++ b/app/client/templates/components/itemSelectedAccount.html
@@ -1,5 +1,5 @@
 <template name="components_itemSelectedAccount">
-    {{#with accounts 'selected'}}
+    {{#with selectedAccount}}
     <a class="row list-group-item selected-account-item"
        href="/accounts/">
         <div class="col-xs-3 col-sm-3 col-md-3">

--- a/app/client/templates/components/itemSelectedAccount.js
+++ b/app/client/templates/components/itemSelectedAccount.js
@@ -1,0 +1,6 @@
+Template['components_itemSelectedAccount'].helpers({
+    'selectedAccount': function(){
+        var selected = LocalStore.get('selectedAddress');
+        return { address: selected };
+    },
+});

--- a/app/client/templates/views/namereg.js
+++ b/app/client/templates/views/namereg.js
@@ -184,7 +184,7 @@ Template['views_namereg'].events({
     'click .btn-deploy': function(event, template){
         TemplateVar.set(template, 'state', {isMining: true, isDeploying: true});
         
-        NameReg.Contract.new(_.extend(transactionObject, {code: NameReg.code}),
+        NameReg.Contract.new(_.extend(transactionObject, {data: NameReg.code}),
                     function(err, result){
             
             if(err)

--- a/app/client/templates/views/namereg.js
+++ b/app/client/templates/views/namereg.js
@@ -43,7 +43,7 @@ Template['views_namereg'].events({
 
     'click .btn-register': function(event, template){
         var value = web3.clean($('#nameregValue').val()),
-            account = accounts.get('selected').address,
+            account = LocalStore.get('selectedAddress'),
             transactionCallback = function(err, result){
                 if(err)
                     return TemplateVar.set(template, 'state', {
@@ -85,7 +85,7 @@ Template['views_namereg'].events({
     */
 
     'click .btn-unregister': function(event, template){
-        var account = accounts.get('selected').address,
+        var account = LocalStore.get('selectedAddress'),
             transactionCallback = function(err, result){
                 if(err) 
                     return TemplateVar.set(template, 'state', {
@@ -128,7 +128,7 @@ Template['views_namereg'].events({
 
     'click .btn-lookup': function(event, template){
         var value = web3.clean($('#nameregValue').val()),
-            account = accounts.get('selected').address,
+            account = LocalStore.get('selectedAddress'),
             nameOfCallback = function(err, result){
                 if(err)
                     return;


### PR DESCRIPTION
Id management for boardroom is a little tricky because of the two categories of identity "node accounts" and "browser accounts". This PR solves some issues where the app was getting the incorrect current user.